### PR TITLE
fix: guard against a null $last when a flow step rejects

### DIFF
--- a/src/flow-manager-directus-flow-hook/index.ts
+++ b/src/flow-manager-directus-flow-hook/index.ts
@@ -157,11 +157,15 @@ export default defineHook(({ action }, { services }) => {
       if (lastExecutionData) {
         const lastStep = lastExecutionData.steps?.[lastExecutionData.steps?.length - 1];
         lastStepStatus = lastStep?.status;
-        if (lastStepStatus === "reject") {  
-          if (Array.isArray(lastExecutionData.data.$last)) {
-            lastStepErrorMessage = lastExecutionData.data.$last[0].message;
+        if (lastStepStatus === "reject") {
+          // A rejected step does not always carry a $last payload. When it is
+          // null, Array.isArray(null) is false, so the else branch used to read
+          // .message off null and throw inside the action handler.
+          const lastError = lastExecutionData.data?.$last;
+          if (Array.isArray(lastError)) {
+            lastStepErrorMessage = lastError[0]?.message ?? "";
           } else {
-            lastStepErrorMessage = lastExecutionData.data.$last.message;
+            lastStepErrorMessage = lastError?.message ?? "";
           }
           lastStepOperation = lastStep.operation;
         }


### PR DESCRIPTION
## The bug

`revisions.create` reads the error message off `lastExecutionData.data.$last` without checking it exists ([`index.ts:160-165`](https://github.com/baguse/directus-extension-flow-manager/blob/master/src/flow-manager-directus-flow-hook/index.ts#L160)):

```ts
if (Array.isArray(lastExecutionData.data.$last)) {
  lastStepErrorMessage = lastExecutionData.data.$last[0].message;
} else {
  lastStepErrorMessage = lastExecutionData.data.$last.message;
}
```

A rejected step does not always carry a `$last` payload. When it is `null`, `Array.isArray(null)` is `false`, so the else branch reads `.message` off `null` and throws inside the action handler:

```
WARN: An error was thrown while executing action "revisions.create"
TypeError: Cannot read properties of null (reading 'message')
    at EventEmitter.<anonymous> (.../directus-extension-flow-manager@1.5.3/dist/api.js)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

Seen on Directus 10.12.1 with v1.5.3, repeating on every affected flow run.

## Why it is worth fixing

Directus catches the throw, so nothing visibly breaks — but the `database("directus_flows").update(...)` below it never runs. `flow_manager_last_run_message`, `flow_manager_last_run_operation` and `flow_manager_error_counter` are all left stale **for exactly the runs where the error information matters most**: the ones that failed.

On a busy instance it also fills the log with stack traces.

## The fix

Reads `$last` once through optional chaining and falls back to `""`, so the update still records the operation and increments the counter even when no message is available. Array elements are guarded too — `$last[0]` can be `null` for the same reason.

## Behaviour

| `data.$last` | before | after |
|---|---|---|
| `null` | **throws** | `""` |
| `undefined` | **throws** | `""` |
| `data` itself undefined | **throws** | `""` |
| `[null]` | **throws** | `""` |
| `{ message: "boom" }` | `"boom"` | `"boom"` |
| `[{ message: "boom" }]` | `"boom"` | `"boom"` |

Well-formed payloads, object or array, are unchanged.

Verified with `npm run build` — builds clean.

Thanks for maintaining this extension, it is genuinely useful.